### PR TITLE
Merge build and test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,31 +34,8 @@ jobs:
       - name: Check Linting
         run: yarn lint
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      # Check out the code in the repository
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      # Set up Node
-      - name: Set Up Node
-        uses: nettbureau/.github/.github/actions/setup-node@main
-        with:
-          nettbureau-auth-token: ${{ secrets.AUTH_TOKEN }}
-          fontawesome-auth-token: ${{ secrets.FONTAWESOME_AUTH_TOKEN }}
-
-      # Install all dependencies
-      - name: Install Dependencies
-        uses: nettbureau/.github/.github/actions/install@main
-
-      # Verify that all the tests pass
-      - name: Check Tests
-        run: yarn test
-
-  build:
-    name: Build
+  build-and-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - name: Set environment variables
@@ -82,3 +59,7 @@ jobs:
       # Verify that the code builds
       - name: Build Code
         run: yarn build
+
+      # Verify that all the tests pass
+      - name: Check Tests
+        run: yarn test


### PR DESCRIPTION
In monorepos the test command often requires all packages to have been built. So it doesn't make that much sense to run these two as two separate tasks.