### PR TITLE
Update actions to use node 16

### DIFF
--- a/.github/workflows/annotate-pr.yml
+++ b/.github/workflows/annotate-pr.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Automatically add the author of the PR as the assignee
       - name: Add Assignee
-        uses: toshimaru/auto-author-assign@v1.4.0
+        uses: toshimaru/auto-author-assign@v1.6.1
         with:
           repo-token: ${{ secrets.REPO_TOKEN }}
 
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Automatically apply labels based on the commits
       - name: Apply Labels
-        uses: fuxingloh/multi-labeler@v1
+        uses: fuxingloh/multi-labeler@v2.0.1
         with:
           github-token: ${{ secrets.REPO_TOKEN }}
           config-path: .github/labeler.yml

--- a/.github/workflows/report-size.yml
+++ b/.github/workflows/report-size.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Comment on the pull request with a report of the size of the files
       - name: Report Size
-        uses: preactjs/compressed-size-action@v2
+        uses: preactjs/compressed-size-action@master
         with:
           pattern: ${{ inputs.pattern }}
           exclude: "{**/*.map,**/node_modules/**}"


### PR DESCRIPTION
Update all actions to their latest version.
Fixes these github warnings:
![Github warnings for node v12 deprecation](https://user-images.githubusercontent.com/67436/205293500-477e870e-198b-4e62-b19a-df64fd75742b.png)
